### PR TITLE
Fix syntax for pointer dereferencing for pool-allocator article

### DIFF
--- a/programming/pool-allocator.html
+++ b/programming/pool-allocator.html
@@ -774,8 +774,8 @@ list, freeing each chunk array and each <code>ArrayStart</code> structure in the
 
     <span style="color: #79a8ff;">ArrayStart</span>* <span style="color: #6ae4b9;">array_start</span> = pool-&gt;array_starts;
     <span style="color: #ff6f9f;">while</span> (array_start != <span style="color: #88ca9f;">NULL</span>) {
-        <span style="color: #79a8ff;">ArrayStart</span>* <span style="color: #6ae4b9;">next</span> = array_start&gt;next;
-        free(array_start&gt;arr);
+        <span style="color: #79a8ff;">ArrayStart</span>* <span style="color: #6ae4b9;">next</span> = array_start-&gt;next;
+        free(array_start-&gt;arr);
         free(array_start);
         array_start = next;
     }

--- a/programming/pool-allocator.org
+++ b/programming/pool-allocator.org
@@ -464,8 +464,8 @@ void pool_close(Pool* pool) {
 
     ArrayStart* array_start = pool->array_starts;
     while (array_start != NULL) {
-        ArrayStart* next = array_start>next;
-        free(array_start>arr);
+        ArrayStart* next = array_start->next;
+        free(array_start->arr);
         free(array_start);
         array_start = next;
     }


### PR DESCRIPTION
Hello 8dcc,

I was just reading through your `pool-allocator` article on HackerNews, and came across this small syntax error. So, I thought I would put out a PR. I don't have `emacs` installed on my system so you would have to re-generate the html file yourself (sorry about that haha). Keep up the good work. Cheers 👍 